### PR TITLE
feat(product-owner): add write-spike skill for exploratory research

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,8 @@
       "name": "product-owner",
       "source": "./plugins/product-owner",
       "description": "Product owner agent and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "commit": "6d9dc3e"
     },
     {
       "name": "cloud-engineering-aws",

--- a/plugins/product-owner/.claude-plugin/plugin.json
+++ b/plugins/product-owner/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "product-owner",
   "description": "Product owner agent and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
-  "version": "0.3.0"
+  "version": "0.3.0",
+  "commit": "6d9dc3e"
 }

--- a/plugins/product-owner/README.md
+++ b/plugins/product-owner/README.md
@@ -12,7 +12,7 @@ The plugin has two modes:
 
 **Work sequencing:** The `product-owner` agent reads your roadmap and advises on ordering, prerequisites, and phase transitions. It pushes back when proposed work skips a dependency or conflicts with what's planned next. It doesn't decide what to build or why; it organizes and sequences the work within the direction you've already set.
 
-**Requirement authoring:** Three skills (`/write-epic`, `/write-story`, `/decompose-requirement`) formalize requirements into structured specifications. Output is designed to be filed directly in issue tracking systems without manual reformatting.
+**Requirement authoring:** Four skills (`/write-spike`, `/write-epic`, `/write-story`, `/decompose-requirement`) formalize requirements. Use `/write-spike` when a work area is too uncertain to scope directly; the other three skills take the output forward.
 
 ## Architecture
 
@@ -51,10 +51,18 @@ When the conversation turns to authoring requirements, the agent delegates to th
 
 ### The skills: authoring layer
 
-The three skills form a natural progression from broad to specific:
+The four skills form a natural progression from broad to specific:
 
 ```
-Feature idea
+Uncertain work area
+    │
+    ▼
+/write-spike ─────────── Resolve uncertainty first
+    │                    Problem restatement, options, findings,
+    │                    remaining unknowns, story seed
+    │
+    ▼
+Feature idea (ready to scope)
     │
     ▼
 /write-epic ──────────── Scope the initiative
@@ -111,6 +119,7 @@ RIF output is structured so that official platform plugins can consume it withou
 | "Should we build X now or later?" | `product-owner` agent |
 | "What's left in this phase?" | `product-owner` agent |
 | "We finished Y. What's next?" | `product-owner` agent |
+| "This area is too uncertain to scope or story-write" | `/write-spike` |
 | "Scope out a new feature area" | `/write-epic` |
 | "Break this epic into stories" | `/decompose-requirement` |
 | "Break this story into subtasks" | `/decompose-requirement` |

--- a/plugins/product-owner/agents/product-owner.md
+++ b/plugins/product-owner/agents/product-owner.md
@@ -6,6 +6,7 @@ memory: project
 skills:
   - write-epic
   - write-story
+  - write-spike
   - decompose-requirement
 ---
 
@@ -60,6 +61,8 @@ When someone proposes a new feature, evaluate:
 - Is it the highest-priority item right now, or should something else come first?
 
 When a proposed feature needs formal scoping, use `/write-epic` to produce a structured epic specification with metadata suitable for filing in issue tracking systems.
+
+If the proposed work is too uncertain to scope or story-write — key questions are unanswered, the approach is unclear, or the scope cannot be bounded — do not produce a poorly-scoped story. Instead, recommend invoking `/write-spike` to resolve the uncertainty first.
 
 ## How to Respond
 
@@ -155,10 +158,11 @@ The user then passes the closure summary to the official github or atlassian Cla
 
 When asked to author requirements:
 
-1. If the request is to scope a new feature area → use `/write-epic`
-2. If the request is to formalize a single work item → use `/write-story`
-3. If the request is to break down an existing requirement into children → use `/decompose-requirement`
-4. After any skill output, review the result against the roadmap and advise on sequencing
+1. If the work area is too uncertain to story-write → use `/write-spike` to produce a findings document first
+2. If the request is to scope a new feature area → use `/write-epic`
+3. If the request is to formalize a single work item → use `/write-story`
+4. If the request is to break down an existing requirement into children → use `/decompose-requirement`
+5. After any skill output, review the result against the roadmap and advise on sequencing
 
 ## What You Do NOT Do
 

--- a/plugins/product-owner/skills/write-spike/SKILL.md
+++ b/plugins/product-owner/skills/write-spike/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: write-spike
+description: "Produce a structured findings document for a topic too uncertain to story-write directly. Covers problem restatement, key questions, options considered, findings, remaining unknowns, and a story seed."
+user-invokable: true
+allowed-tools: Read, Grep, Glob, WebSearch, WebFetch
+argument-hint: "[topic or question driving the investigation]"
+---
+
+# Write Spike
+
+Produce a structured findings document that resolves enough uncertainty to let the product owner write a well-formed user story.
+
+## Input
+
+`$ARGUMENTS` = the topic, question, or work area that is too uncertain to story-write directly.
+
+## Process
+
+### 1. Gather Context
+
+- Read the project's CLAUDE.md for architecture, domain language, and constraints
+- Scan for a roadmap or backlog file if one exists (Glob for roadmap*, backlog*, TODO*)
+- Identify any existing work or decisions that bear on the topic
+
+### 2. Scope the Investigation
+
+State clearly:
+
+- **The driving question**: What specific question does this spike need to answer? Narrow to one well-formed question if the input is broad.
+- **Why now**: What decision or story is blocked until this question is answered?
+- **Out of scope**: What related questions will be explicitly deferred?
+
+A spike that tries to answer three questions usually answers none well.
+
+### 3. Explore the Topic
+
+Research the topic through whatever means are available:
+
+- Read relevant source files if the topic is code or architecture
+- Search for documentation, prior art, or established patterns (WebSearch / WebFetch)
+- Enumerate options or approaches with concrete trade-offs — not just "Option A vs Option B" but specific pros, cons, and constraints for this project
+- Note sources and links for evidence that will be referenced in the output
+
+### 4. Assess Story Readiness
+
+Before producing output, evaluate:
+
+- Can the driving question be answered with enough confidence to write a story?
+- Are there remaining unknowns that would block story writing or cause the story to be poorly scoped?
+- If unknowns remain, identify a concrete follow-up action for each (prototype, user interview, additional reading, architectural decision)
+
+### 5. Produce Structured Output
+
+Construct the YAML frontmatter metadata block:
+
+- `type`: always `spike`
+- `title`: verb-led, describes the investigation (e.g., "Investigate caching options for product search API")
+- `topic`: the single driving question in one sentence
+- `labels`: prefix with `area:` for domain labels
+- `priority`: `critical`, `high`, `medium`, or `low`
+- `status`: always `draft`
+- `story_seed`: a one-sentence story starter or recommended next action — omit if findings are inconclusive
+
+## Output
+
+Print YAML frontmatter followed by the findings document body. Example:
+
+```yaml
+---
+type: spike
+title: "Investigate authentication options for mobile API"
+topic: "Which auth approach (OAuth2, API key, or JWT) best fits our mobile client constraints?"
+labels:
+  - "area:auth"
+  - "area:mobile"
+priority: high
+status: draft
+story_seed: "Add JWT-based authentication to the mobile API client"
+---
+
+## Problem Restatement
+
+The mobile client needs to authenticate against the API, but it is unclear which approach fits the
+constraints: no server-side session storage, short-lived tokens preferred, and support for
+offline-first operation.
+
+## Key Questions Explored
+
+- Can OAuth2 work without a browser redirect in the mobile context?
+- Does JWT satisfy the offline-first requirement without a token-refresh round-trip?
+- What is the operational cost of rotating API keys vs. refreshing tokens?
+
+## Options Considered
+
+| Option | Pros | Cons |
+|---|---|---|
+| OAuth2 (authorization code) | Industry standard, revocable | Requires browser redirect; complex for native clients |
+| API key | Simple to implement | Long-lived; revocation requires key rotation; poor for multi-device |
+| JWT (short-lived + refresh) | Stateless, offline-capable, revocable via refresh rotation | Refresh token storage adds complexity |
+
+## Findings
+
+JWT with short-lived access tokens and a rotating refresh token is the best fit. It satisfies
+the offline-first constraint (access token valid for 15 minutes without network), avoids
+browser redirects, and allows revocation by invalidating the refresh token. The operational
+overhead of a refresh endpoint is justified by the security and UX benefits.
+
+OAuth2 was ruled out because the authorization code flow requires a browser redirect — viable
+for web but disruptive in a native mobile app. API keys were ruled out due to long-lived
+credentials and no per-device revocation.
+
+## Remaining Unknowns
+
+- **Refresh token storage on device**: Where to securely store the refresh token on iOS and
+  Android is not resolved. Follow-up: evaluate Keychain (iOS) and Keystore (Android) before
+  implementing.
+
+## Story Seed
+
+Add JWT-based authentication to the mobile API client, using short-lived access tokens and a
+rotating refresh token stored in platform-native secure storage.
+```


### PR DESCRIPTION
## Summary

- Adds the `/write-spike` skill for resolving work areas too uncertain to story-write directly
- Updates the `product-owner` agent with trigger language and delegation references for `/write-spike`
- Updates README with updated description, flow diagram showing `/write-spike` as a pre-step, and new "When to use what" table row

## What the skill does

Produces a structured findings document covering problem restatement, key questions, options considered, findings, remaining unknowns, and a story seed — giving the PO enough context to then invoke `/write-epic` or `/write-story`.

## Test plan

- [ ] Invoke `/write-spike <topic>` and verify the skill produces YAML frontmatter + structured findings body
- [ ] Verify SKILL.md frontmatter has no `context: fork` line
- [ ] Verify agent body has two `/write-spike` trigger references (Scope Check + Requirement Authoring sections)
- [ ] Verify README flow diagram shows `/write-spike` as a pre-step before `/write-epic`
- [ ] Verify README "When to use what" table includes the `/write-spike` row

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)