### PR TITLE
feat(write-story): encode agile best practices from audit (#16)

### DIFF
--- a/plugins/product-owner/skills/write-story/SKILL.md
+++ b/plugins/product-owner/skills/write-story/SKILL.md
@@ -22,7 +22,16 @@ Write a complete, high-quality user story with structured metadata ready for Git
 - Scan for a roadmap or backlog file if one exists (Glob for roadmap*, backlog*, TODO*)
 - Understand the domain well enough to write specific, testable criteria
 
+**Readiness assessment:**
+
+- If the story has hard blockers on unstarted work (entire epics or phases that have not begun), classify readiness as `backlog` and skip to the Backlog-Tier Output section at the end of this skill
+- If dependencies are complete or actively in-progress, classify readiness as `sprint-ready` and continue the full process below
+
+Detailed specification should happen at pull time, not envisioning time. Stories deep in the backlog will change as the project evolves — investing in full acceptance criteria and technical notes for work that is months away produces waste. A lightweight backlog entry captures intent and scope; the full story gets written when the team is ready to start.
+
 ### 2. Draft the Story
+
+> **Gate:** If readiness is `backlog`, skip to the **Backlog-Tier Output** section.
 
 **Title**: Action-oriented, concise, starts with a verb.
 
@@ -59,6 +68,31 @@ Include at minimum:
 - **Files likely affected**: [key modules — only if codebase context is available from step 1]
 ```
 
+**What to avoid in acceptance criteria:**
+
+Acceptance criteria must describe behavior observable by the persona, not internal system mechanics. Given/When/Then steps use domain language, not protocol or implementation language.
+
+| Bad (implementation detail) | Good (domain behavior) |
+|-----------------------------|------------------------|
+| "then the API returns HTTP 201" | "then the order appears in the customer's order history" |
+| "then the response body contains `{ status: 'ok' }`" | "then a confirmation message is displayed" |
+| "when `createUser()` is called" | "when the visitor submits the registration form" |
+| "then a row is inserted into the `notifications` table" | "then the customer receives a notification within 60 seconds" |
+
+**Hard rule:** If an acceptance criterion references implementation artifacts (HTTP status codes, JSON shapes, file paths, function signatures, database columns), rewrite it in domain language and move the implementation detail to Technical Notes.
+
+**Definition of Done guidance:**
+
+Stories reference a project-level Definition of Done rather than repeating completion standards inline. Emit a `## Definition of Done` section ONLY when the story has requirements beyond the project standard.
+
+Examples of story-specific DoD items (include only when applicable):
+
+- An ADR is required for the architectural decision introduced by this story
+- The runbook must be validated in staging before the story is accepted
+- A load test must demonstrate the endpoint handles 500 req/s at p99 < 200ms
+
+When present, place the `## Definition of Done` section after Technical Notes in the story body.
+
 ### 3. Validate with INVEST
 
 Check every story against all six criteria before finalizing:
@@ -69,12 +103,12 @@ Check every story against all six criteria before finalizing:
 | **Negotiable** | Does it describe the *what/why* and leave room for *how*? | Specifies UI layout, API shape, or implementation approach |
 | **Valuable** | Does the benefit statement name a real outcome for the role? | "So that the code is cleaner" — that's a refactor, not a user story |
 | **Estimable** | Is there enough detail to estimate effort? | Vague scope, unknown integration, missing constraints |
-| **Small** | Can it be completed in a single sprint? | Epic-sized: "As a user, I want authentication" |
+| **Small** | Can it be completed in a single PR? | Epic-sized scope, AC grouped under sub-headings, more than 7-8 acceptance criteria |
 | **Testable** | Can every acceptance criterion be verified with a concrete test? | "Works correctly", "Handles all edge cases" |
 
 If a criterion fails, fix the story before output. Common fixes:
 
-- **Too large** — Split vertically by user-visible slice, not by technical layer
+- **Too large** — Detection signals: AC grouped under sub-headings, more than 7-8 criteria, implementation spanning multiple PRs. Split vertically by user-visible slice, not by technical layer. Use `/decompose-requirement` when any signal fires
 - **Not independent** — Merge with the dependency or extract a shared prerequisite
 - **Not valuable** — Rewrite with a real user outcome, or reclassify as a technical task
 - **Not testable** — Replace vague criteria with specific Given/When/Then
@@ -107,6 +141,7 @@ Construct the YAML frontmatter metadata block:
 - `labels`: prefix with `area:` for domain labels
 - `size`: `XS`, `S`, `M`, `L`, or `XL`
 - `status`: always `draft`
+- `readiness`: `backlog` or `sprint-ready` — determined in step 1
 - `recommended_model`: `haiku`, `sonnet`, or `opus` — determined in step 4
 - `dependencies`: list of `blocked_by` objects with `reason`; omit if none
 - `acceptance_criteria`: the same criteria as in the body, as a structured list for downstream tools
@@ -122,7 +157,7 @@ Before presenting the story, verify:
 - [ ] Benefit is an outcome, not a restatement of the capability
 - [ ] Every acceptance criterion is independently testable without reading other criteria
 - [ ] Error cases are covered — not just the happy path
-- [ ] No implementation details in the story body (those belong in technical notes only)
+- [ ] No implementation details in acceptance criteria — check for HTTP status codes, JSON shapes, file paths, function signatures, and database columns; rewrite any offenders in domain language and move detail to Technical Notes
 - [ ] Technical notes describe constraints and outcomes, not methods
 - [ ] Scope size is present
 - [ ] `recommended_model` is present and rationale is included in Technical Notes
@@ -141,6 +176,7 @@ labels:
   - "area:orders"
 size: M
 status: draft
+readiness: sprint-ready
 recommended_model: sonnet
 dependencies:
   - blocked_by: "Implement order approval workflow"
@@ -169,4 +205,37 @@ so that I know my order is being processed without needing to check the website.
 - **Dependencies**: Requires the order approval event from the order workflow service
 - **Constraints**: Email must be sent asynchronously; must comply with CAN-SPAM
 - **Recommended model**: sonnet — multi-step async flow with cross-service integration warrants the workhorse model
+```
+
+### Backlog-Tier Output
+
+Use this format when readiness is `backlog` — the story has hard blockers on unstarted work and full specification would be premature.
+
+**Skip:** acceptance criteria, technical notes, model recommendation, INVEST validation.
+
+```yaml
+---
+type: story
+title: "Add webhook delivery for billing events"
+parent: "Billing Integration"
+labels:
+  - "area:billing"
+  - "area:integrations"
+size: M
+status: draft
+readiness: backlog
+dependencies:
+  - blocked_by: "Implement billing event pipeline"
+    reason: "Billing events must be emitted before webhooks can deliver them"
+---
+
+## User Story
+
+As an **integration partner**,
+I want to receive webhook notifications when billing events occur,
+so that I can keep my systems in sync without polling.
+
+**Scope:** Covers webhook registration, delivery with retries, and a delivery log. Does not cover webhook signature verification (separate story).
+
+**Why backlog:** The billing event pipeline (parent epic) has not started; detailed AC will be specified when this story is pulled into a sprint.
 ```


### PR DESCRIPTION
## Summary

- Add readiness gate (`backlog` vs `sprint-ready`) to prevent premature specification of stories blocked on unstarted work
- Tighten acceptance criteria guidance to require domain language over implementation details (contrast table + hard rule)
- Add Definition of Done guidance — reference project-level DoD, only emit story-specific items
- Strengthen INVEST "Small" criterion to target single-PR scope with detection signals and explicit `/decompose-requirement` recommendation
- Add lightweight backlog-tier output format with complete example

Closes #16

## Test plan

- [ ] Read modified `SKILL.md` end-to-end for structural consistency
- [ ] Verify blank-line conventions per CLAUDE.md (MD022/MD032)
- [ ] Confirm backlog-tier YAML example is valid
- [ ] Run `/write-story` on a test prompt to confirm the skill executes with the new guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)