### PR TITLE
feat: add context sufficiency check to write-story skill

### DIFF
--- a/plugins/product-ops/README.md
+++ b/plugins/product-ops/README.md
@@ -111,20 +111,24 @@ RIF output is structured so that official platform plugins can consume it withou
 
 ### `/write-story` authoring flow
 
-The most complex skill in the plugin. This diagram traces the end-to-end path from invocation to delivered output, including the Step 1 readiness gate and the Step 7 peer-review category split.
+The most complex skill in the plugin. This diagram traces the end-to-end path from invocation to delivered output, including the Step 1 readiness gate, the Step 2 context sufficiency check, and the Step 8 peer-review category split.
 
 ```mermaid
 flowchart TD
     A["/write-story"] --> S1["1 · Gather Context"]
     S1 --> Gate{"Readiness?"}
     Gate -- "backlog" --> BT["Backlog-Tier Output<br/>(stub story only)"]
-    Gate -- "sprint-ready" --> S2["2 · Draft Story"]
-    S2 --> S3["3 · INVEST Validation"]
-    S3 --> S4["4 · Model Tier Selection"]
-    S4 --> S5["5 · Structured Output"]
-    S5 --> S6["6 · Final Quality Check"]
-    S6 --> S7["7 · /refine-story peer review"]
-    S7 --> Cat{"Categorize<br/>each failure"}
+    Gate -- "sprint-ready" --> S2["2 · Assess Context Sufficiency"]
+    S2 --> Suf{"All dimensions<br/>sufficient?"}
+    Suf -- "yes" --> S3
+    Suf -- "no" --> Prompt["Prompt for<br/>missing dimensions"]
+    Prompt --> S3
+    S3["3 · Draft Story"] --> S4["4 · INVEST Validation"]
+    S4 --> S5["5 · Model Tier Selection"]
+    S5 --> S6["6 · Structured Output"]
+    S6 --> S7["7 · Final Quality Check"]
+    S7 --> S8["8 · /refine-story peer review"]
+    S8 --> Cat{"Categorize<br/>each failure"}
     Cat -- "Craft issues" --> Fix["Apply fixes to story<br/>Record in Change Summary"]
     Cat -- "Product concerns" --> Collect["Collect for user"]
     Cat -- "All pass" --> Deliver

--- a/plugins/product-ops/skills/write-story/SKILL.md
+++ b/plugins/product-ops/skills/write-story/SKILL.md
@@ -29,7 +29,26 @@ Write a complete, high-quality user story with structured metadata and a human-r
 
 Detailed specification should happen at pull time, not envisioning time. Stories deep in the backlog will change as the project evolves — investing in full acceptance criteria and technical notes for work that is months away produces waste. A lightweight backlog entry captures intent and scope; the full story gets written when the team is ready to start.
 
-### 2. Draft the Story
+### 2. Assess Context Sufficiency
+
+> **Gate:** If readiness is `backlog`, skip to the **Backlog-Tier Output** section.
+
+Before drafting, evaluate whether the input provides enough detail across four dimensions:
+
+| Dimension | Sufficient when | Prompt if underspecified |
+|-----------|----------------|--------------------------|
+| **Persona** | A specific role or actor is named or clearly implied | "Who is the primary user or actor for this requirement?" |
+| **Observable behavior** | The desired system behavior is concrete enough to demonstrate | "What should the system do — what would a user see or experience?" |
+| **Benefit / motivation** | A reason or outcome beyond restating the capability is present | "Why does this matter — what problem does it solve or what outcome does it enable?" |
+| **Scope boundaries** | At least a rough sense of what is in and out of scope is present | "What is explicitly out of scope or deferred for this work?" |
+
+**Outcome paths:**
+
+- **All sufficient** — proceed to Step 3 immediately. Do not prompt.
+- **One or more underspecified** — present targeted questions for only the underspecified dimensions in a single consolidated prompt. Incorporate the answers into your working context, then proceed to Step 3.
+- **No response (non-interactive context)** — infer reasonable answers from available project context (CLAUDE.md, roadmap, codebase). Record each inference in Technical Notes with the prefix "Inferred:" so the contributor can verify.
+
+### 3. Draft the Story
 
 > **Gate:** If readiness is `backlog`, skip to the **Backlog-Tier Output** section.
 
@@ -93,7 +112,7 @@ Examples of story-specific DoD items (include only when applicable):
 
 When present, place the `## Definition of Done` section after Technical Notes in the story body.
 
-### 3. Validate with INVEST
+### 4. Validate with INVEST
 
 Check every story against all six criteria before finalizing:
 
@@ -113,7 +132,7 @@ If a criterion fails, fix the story before output. Common fixes:
 - **Not valuable** — Rewrite with a real user outcome, or reclassify as a technical task
 - **Not testable** — Replace vague criteria with specific Given/When/Then
 
-### 4. Select Model Tier
+### 5. Select Model Tier
 
 Reason across three dimensions to select `recommended_model`:
 
@@ -129,26 +148,26 @@ Reason across three dimensions to select `recommended_model`:
 - **sonnet** — M or L size, multi-step reasoning, cross-file changes, API design decisions, or ambiguous scope. Default for most stories.
 - **opus** — Correctness-critical work (security, data integrity, complex algorithms), deep multi-layer debugging, or stories where Sonnet has previously struggled on similar work. Always include explicit rationale when recommending opus.
 
-Record the chosen tier and a one-sentence rationale. Both appear in step 5 (frontmatter) and in the Technical Notes section of the story body.
+Record the chosen tier and a one-sentence rationale. Both appear in step 6 (frontmatter) and in the Technical Notes section of the story body.
 
-### 5. Produce Structured Output
+### 6. Produce Structured Output
 
 Construct the YAML frontmatter metadata block:
 
 - `type`: always `story`
-- `title`: the verb-led title from step 2
+- `title`: the verb-led title from step 3
 - `parent`: parent epic title, if known
 - `labels`: prefix with `area:` for domain labels
 - `size`: `XS`, `S`, `M`, `L`, or `XL`
 - `status`: always `draft`
 - `readiness`: `backlog` or `sprint-ready` — determined in step 1
-- `recommended_model`: `haiku`, `sonnet`, or `opus` — determined in step 4
+- `recommended_model`: `haiku`, `sonnet`, or `opus` — determined in step 5
 - `dependencies`: list of `blocked_by` objects with `reason`; omit if none
 - `acceptance_criteria`: the same criteria as in the body, as a structured list for downstream tools
 
 Acceptance criteria appear in **both** the YAML metadata (structured list for downstream tools) and the markdown body (human-readable checklist with `- [ ]`). This deliberate duplication serves both audiences.
 
-### 6. Final Quality Check
+### 7. Final Quality Check
 
 Before presenting the story, verify:
 
@@ -162,9 +181,9 @@ Before presenting the story, verify:
 - [ ] Scope size is present
 - [ ] `recommended_model` is present and rationale is included in Technical Notes
 
-### 7. Peer Review
+### 8. Peer Review
 
-**Delivery guarantee:** This step MUST conclude with the complete formatted story (Sections 1 and 2 from step 5) as the primary output. Nothing — no review feedback, coaching report, or product concern — replaces or defers the story delivery.
+**Delivery guarantee:** This step MUST conclude with the complete formatted story (Sections 1 and 2 from step 6) as the primary output. Nothing — no review feedback, coaching report, or product concern — replaces or defers the story delivery.
 
 Run `/refine-story` on the draft story. Categorize every failing item into one of two categories and handle it accordingly:
 
@@ -194,7 +213,7 @@ For **sprint-ready** stories, the markdown body MUST follow this exact section o
 2. `## Acceptance Criteria`
 3. `## Technical Notes`
 4. `## Definition of Done` *(optional — only when story-specific DoD items exist beyond the project standard)*
-5. `## Change Summary` *(optional — present only when Step 7 peer review resulted in revisions; one bullet per change with rationale)*
+5. `## Change Summary` *(optional — present only when Step 8 peer review resulted in revisions; one bullet per change with rationale)*
 
 Additional rules:
 
@@ -255,7 +274,7 @@ so that I know my order is being processed without needing to check the website.
 
 ### Product Considerations (conditional)
 
-Present this section AFTER the complete story output (Sections 1 and 2) when Step 7 identified product concerns. This section is NOT part of the story artifact — it is not included in the YAML metadata or the story body.
+Present this section AFTER the complete story output (Sections 1 and 2) when Step 8 identified product concerns. This section is NOT part of the story artifact — it is not included in the YAML metadata or the story body.
 
 For each product concern:
 
@@ -265,7 +284,7 @@ For each product concern:
 
 End with: "For interactive coaching on any of these concerns, consult `agile-coach`."
 
-Omit this section entirely when no product concerns were identified in Step 7.
+Omit this section entirely when no product concerns were identified in Step 8.
 
 ### Backlog-Tier Output
 


### PR DESCRIPTION
## Summary
- Adds Step 2 "Assess Context Sufficiency" to `/write-story` that evaluates four dimensions (persona, observable behavior, benefit/motivation, scope boundaries) before drafting begins
- Prompts the user for only the underspecified dimensions in a single consolidated prompt, avoiding unnecessary questions when context is already sufficient
- Renumbers subsequent steps (3–8) and updates all internal cross-references and the Mermaid flow diagram in the product-ops README

Closes #25

## Test plan
- [ ] Invoke `/write-story` with a vague one-line requirement (e.g., "fix the naming issue") and confirm targeted prompts appear before drafting
- [ ] Invoke `/write-story` with a well-specified requirement and confirm no prompts are issued
- [ ] Verify all step numbers in SKILL.md are sequential 1–8 with no gaps
- [ ] Verify all cross-references point to the correct renumbered steps
- [ ] Verify the Mermaid diagram in README.md renders correctly and node labels match SKILL.md step names

🤖 Generated with [Claude Code](https://claude.com/claude-code)