### PR TITLE
docs: add flow-diagram sync convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,24 @@ A Claude Code plugin marketplace containing reusable agents and skills organized
 - The harness executes tool calls in-process (Python functions), bypassing MCP/skill transport — it only needs the JSON data files
 - Tests live in `benchmark/tests/` and use pytest; run with `cd benchmark && pytest`
 
+### Flow Diagrams
+
+Plugin READMEs may include Mermaid flow diagrams that visualize skill authoring flows and agent delegation routing. Keep these diagrams in sync with their corresponding skill or agent behavior.
+
+**Changes that require diagram updates:**
+
+- Skill process steps added, removed, or reordered (e.g., a new gate or branch in a skill's step sequence)
+- Agent delegation rules changed (e.g., which agent owns a review path, when one agent hands off to another)
+- Authoring flow behavior changed (e.g., a new conditional branch, a new output path, a changed decision point)
+
+**Changes that do not require diagram updates:**
+
+- Wording fixes or copy edits to prose descriptions
+- Metadata adjustments (frontmatter fields, YAML values) that don't alter flow logic
+- Adding or removing examples that don't change the documented process
+
+When writing a story that touches skill process steps, agent delegation rules, or authoring flow behavior, include a Definition of Done item: "Update the corresponding Mermaid flow diagram in the plugin README to reflect the changed behavior."
+
 ### README
 - Keep README.md in sync with any changes to plugins, agents, or skills
 - The Plugins section tables must reflect current agent/skill names and descriptions


### PR DESCRIPTION
## Summary

- Adds a `### Flow Diagrams` section to `CLAUDE.md` establishing a convention that Mermaid flow diagrams must be kept in sync with skill and agent behavior changes
- Distinguishes diagram-triggering changes (process step additions/removals, delegation rule changes, new flow branches) from non-triggering ones (wording fixes, metadata adjustments, example edits)
- Includes an explicit Definition of Done sentence for `/write-story` to emit when authoring stories that touch flow behavior

## Test plan

- [ ] Open `CLAUDE.md` and verify the `### Flow Diagrams` section is present under Authoring Conventions
- [ ] Verify the two sub-lists clearly separate what requires diagram updates from what does not
- [ ] Verify the DoD sentence at the end is actionable enough for `/write-story` to emit a story-specific DoD item
- [ ] Cross-check the convention wording against the existing diagrams in `plugins/product-ops/README.md` — they should be consistent

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)