### PR TITLE
fix: correct product-ops plugin name and description in metadata files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,10 +5,10 @@
   },
   "plugins": [
     {
-      "name": "product-owner",
+      "name": "product-ops",
       "source": "./plugins/product-ops",
-      "description": "Product owner agent and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
-      "version": "0.7.0"
+      "description": "Product ownership and agile coaching agents and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
+      "version": "0.8.0"
     },
     {
       "name": "cloud-engineering-aws",

--- a/plugins/product-ops/.claude-plugin/plugin.json
+++ b/plugins/product-ops/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "product-owner",
-  "description": "Product owner agent and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
-  "version": "0.7.0"
+  "name": "product-ops",
+  "description": "Product ownership and agile coaching agents and skills for roadmap planning, requirement authoring, and epic/story decomposition with structured output for GitHub Issues and Jira",
+  "version": "0.8.0"
 }


### PR DESCRIPTION
## Summary

- Fixes stale `product-owner` name (left from a prior rename) to `product-ops` in `plugins/product-ops/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- Updates description to mention both product ownership and agile coaching capabilities
- Bumps version to `0.8.0` (breaking name change under semver)

Closes #23

## Test plan

- [ ] Verify `plugins/product-ops/.claude-plugin/plugin.json` has `"name": "product-ops"` and `"version": "0.8.0"`
- [ ] Verify `.claude-plugin/marketplace.json` entry has `"name": "product-ops"`, matching description, and `"version": "0.8.0"`
- [ ] Confirm no other references to `product-owner` remain in plugin metadata files

🤖 Generated with [Claude Code](https://claude.com/claude-code)