### PR TITLE
feat: add out-of-band artifact delivery check to deployment guidance

### DIFF
--- a/plugins/cloud-engineering-aws/agents/devops-lead.md
+++ b/plugins/cloud-engineering-aws/agents/devops-lead.md
@@ -66,6 +66,7 @@ When downstream agents consult you, evaluate whether their proposed approach:
 3. Consider database migration risk (the highest-risk part of any deploy)
 4. Frame improvements as maturity tiers — do not jump to blue-green when image tagging would be the right next step
 5. **Active outage:** If production is degraded following a release, instruct the operator to roll back before diagnosing. A fix-and-redeploy cycle while production is down adds risk, not confidence. Switch to the Incident Response pattern for the full Detect → Assess → Restore → Diagnose → Fix → Postmortem sequence.
+6. **Out-of-band artifact delivery:** Flag any runtime artifact the application requires at startup — configuration files, credentials, ML models, certificates, compiled assets, or feature flag configs — that is excluded from the primary build artifact and has no identifiable automated delivery step. Ask: "How does this artifact reach the runtime environment?" When designing a pipeline, include a pre-condition check that verifies required out-of-band artifacts are present or available before deployment proceeds. When answering questions about deploy pre-conditions or deployment checklists, include verifying that all required runtime artifacts have a documented and validated delivery path.
 
 ### Observability and Alerting
 
@@ -151,6 +152,8 @@ Invoke `/write-runbook $ARGUMENTS` where `$ARGUMENTS` is the alert name, service
 
 8. **Non-blocking defaults for log inspection.** In a diagnostic context, log commands and operational scripts that default to live-tail mode block the operator's terminal and add avoidable time to diagnosis. Flag live-tail mode as a risk when it is the default for quick log inspection. Recommend the non-blocking variant as the default and provide the live-tail variant separately, labeled by purpose (diagnostic quick-look vs. live-tail monitoring).
 
+9. **Out-of-band artifact delivery is a deployment pre-condition.** Any runtime artifact the application requires at startup — regardless of deploy target (container, VM, serverless, bare metal) — must have an identified, automated delivery path. If a required artifact is excluded from the primary build artifact and has no delivery step, flag it as a deployment risk before recommending a deployment plan. An undelivered artifact is a startup failure waiting to happen.
+
 ## Key Knowledge
 
 ### Core Principles (tool-agnostic)
@@ -194,8 +197,10 @@ For every practice area, define three tiers. Identify where the project is today
 - Health checks should gate traffic, not just confirm the process started
 - Database migrations are the highest-risk part of any deploy
 - "If you can't roll back in 5 minutes, you shouldn't deploy on Friday"
+- **Out-of-band artifact delivery completeness:** Every runtime artifact the application requires at startup must have an automated delivery path. Artifacts excluded from the primary build artifact — by exclusion convention, secret management policy, or any other reason — must have an explicit delivery step. If no delivery path can be identified, flag it as a deployment risk and ask how the artifact reaches the runtime environment.
 
 ### Deployment Strategies (decide based on risk tolerance)
+
 | Strategy | Risk | Rollback Speed | Complexity |
 |---|---|---|---|
 | Rolling | Medium | Minutes | Low |
@@ -225,6 +230,7 @@ For every practice area, define three tiers. Identify where the project is today
 - Off-site replication before cross-region redundancy
 
 ### Environment Promotion Pattern
+
 ```
 feature branch → dev (auto-deploy on merge)
                   → staging (promote on approval)

--- a/plugins/cloud-engineering-aws/agents/devops-lead.md
+++ b/plugins/cloud-engineering-aws/agents/devops-lead.md
@@ -66,7 +66,7 @@ When downstream agents consult you, evaluate whether their proposed approach:
 3. Consider database migration risk (the highest-risk part of any deploy)
 4. Frame improvements as maturity tiers — do not jump to blue-green when image tagging would be the right next step
 5. **Active outage:** If production is degraded following a release, instruct the operator to roll back before diagnosing. A fix-and-redeploy cycle while production is down adds risk, not confidence. Switch to the Incident Response pattern for the full Detect → Assess → Restore → Diagnose → Fix → Postmortem sequence.
-6. **Out-of-band artifact delivery:** Flag any runtime artifact the application requires at startup — configuration files, credentials, ML models, certificates, compiled assets, or feature flag configs — that is excluded from the primary build artifact and has no identifiable automated delivery step. Ask: "How does this artifact reach the runtime environment?" When designing a pipeline, include a pre-condition check that verifies required out-of-band artifacts are present or available before deployment proceeds. When answering questions about deploy pre-conditions or deployment checklists, include verifying that all required runtime artifacts have a documented and validated delivery path.
+6. **Out-of-band artifact delivery:** Flag any runtime artifact the application requires — configuration files, credentials, ML models, certificates, or feature flag configs — that is excluded from the deployment unit (container image, deployment package, or equivalent) and has no identified, automated delivery step. Ask: "How does this artifact reach the runtime environment?" When designing a pipeline, include a pre-condition check that verifies required out-of-band artifacts are present or available before deployment proceeds. When answering questions about deploy pre-conditions or deployment checklists, include verifying that all required runtime artifacts have an automated and validated delivery path.
 
 ### Observability and Alerting
 
@@ -152,7 +152,7 @@ Invoke `/write-runbook $ARGUMENTS` where `$ARGUMENTS` is the alert name, service
 
 8. **Non-blocking defaults for log inspection.** In a diagnostic context, log commands and operational scripts that default to live-tail mode block the operator's terminal and add avoidable time to diagnosis. Flag live-tail mode as a risk when it is the default for quick log inspection. Recommend the non-blocking variant as the default and provide the live-tail variant separately, labeled by purpose (diagnostic quick-look vs. live-tail monitoring).
 
-9. **Out-of-band artifact delivery is a deployment pre-condition.** Any runtime artifact the application requires at startup — regardless of deploy target (container, VM, serverless, bare metal) — must have an identified, automated delivery path. If a required artifact is excluded from the primary build artifact and has no delivery step, flag it as a deployment risk before recommending a deployment plan. An undelivered artifact is a startup failure waiting to happen.
+9. **Out-of-band artifact delivery is a deployment pre-condition.** Any runtime artifact the application requires — regardless of deploy target (container, VM, serverless, bare metal) — must have an identified, automated delivery path. If a required artifact is excluded from the deployment unit and has no automated delivery step, flag it as a deployment risk before recommending a deployment plan. An undelivered artifact is a runtime failure waiting to happen — either at startup or at the first code path that requires it.
 
 ## Key Knowledge
 
@@ -197,7 +197,7 @@ For every practice area, define three tiers. Identify where the project is today
 - Health checks should gate traffic, not just confirm the process started
 - Database migrations are the highest-risk part of any deploy
 - "If you can't roll back in 5 minutes, you shouldn't deploy on Friday"
-- **Out-of-band artifact delivery completeness:** Every runtime artifact the application requires at startup must have an automated delivery path. Artifacts excluded from the primary build artifact — by exclusion convention, secret management policy, or any other reason — must have an explicit delivery step. If no delivery path can be identified, flag it as a deployment risk and ask how the artifact reaches the runtime environment.
+- **Out-of-band artifact delivery completeness:** Every runtime artifact the application requires must have an identified, automated delivery path. Artifacts excluded from the deployment unit — even intentionally, such as by secret management policy — must have an explicit, automated delivery step. Intentional exclusion is not a delivery path. If no automated delivery path can be identified, flag it as a deployment risk and ask how the artifact reaches the runtime environment.
 
 ### Deployment Strategies (decide based on risk tolerance)
 


### PR DESCRIPTION
## Summary

- Adds step 6 to **Deployment Strategy** response pattern: flag any required runtime artifact that is excluded from the primary build artifact and has no identifiable automated delivery step; ask how it reaches the runtime environment; require a pre-condition check in pipeline designs
- Adds **Rule 9** to the Rules section: out-of-band artifact delivery is a deployment pre-condition, regardless of deploy target
- Adds bullet to **Key Knowledge → Deployment Safety**: every startup artifact must have an automated delivery path; missing delivery paths are flagged as deployment risks
- Fixes two pre-existing MD022 violations (missing blank line after `### Deployment Strategies` and `### Environment Promotion Pattern` headings)

Closes #46

## Test plan

- [ ] Given a deploy pipeline review where a required runtime file (e.g. a config file, ML model, or certificate) has no delivery step, the agent flags it as a deployment risk and asks "How does this artifact reach the runtime environment?"
- [ ] Given a pipeline design request, the agent includes a pre-condition check verifying required out-of-band artifacts are present before deployment proceeds
- [ ] Given a question about deploy pre-conditions or deployment checklists, the agent's response includes verifying that all required runtime artifacts have a documented and validated delivery path
- [ ] `markdownlint` reports no MD022/MD032 errors on `devops-lead.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)